### PR TITLE
Revise copyOnly logic in package.js to avoid false positives

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,6 +3,11 @@ var miniExcludes = {
 		"xstyle/README.md": 1,
 		"xstyle/package": 1
 	},
+	copyOnlyRe = [
+		/\/build/, // contents of build folder and build.js
+		/\/core\//, // contents of core folder
+		/\/xstyle\.min/ // xstyle.min.*
+	],
 	isTestRe = /\/test\//;
 
 var profile = {
@@ -18,8 +23,14 @@ var profile = {
 		amd: function(filename, mid){
 			return /\.js$/.test(filename);
 		},
+		
 		copyOnly: function(filename, mid){
-			return /build/.test(filename) || /xstyle\.min/.test(filename) || /amdLoader/.test(filename) || /core\/put/.test(filename);
+			for(var i = copyOnlyRe.length; i--;){
+				if(copyOnlyRe[i].test(mid)){
+					return true;
+				}
+			}
+			return false;
 		}
 	}
 };


### PR DESCRIPTION
Currently, the `copyOnly` logic in `package.js` runs various regular expressions against the `filename` argument.  However, since that argument includes the entire absolute path to each file being processed, it's possible to result in false positives - for example, if you run a build from underneath a directory containing the word `build` itself, then every resource in xstyle will be marked as `copyOnly`.

This changeset modifies the `copyOnly` logic to check against the `mid` instead, and moves the regular expressions that are being checked into an array for easier maintenance.
