### PR TITLE
Don't strip out escape characters in rule values.

### DIFF
--- a/core/parser.js
+++ b/core/parser.js
@@ -175,11 +175,10 @@ define('xstyle/core/parser', ['xstyle/core/utils'], function(utils){
 							if(!parsed){ // no match for the end of the string
 								error('unterminated string');
 							}
-							var str = parsed[1].replace(/\\/g, ''); // the contents of the string
 							// move the css parser up to the end of the string position
 							cssScan.lastIndex = quoteScan.lastIndex;
 							// push the string on the current value and keep parsing
-							addInSequence(new LiteralString(str));
+							addInSequence(new LiteralString(parsed[1]));
 							selector += parsed[0];
 							continue;
 						case '\\':

--- a/test/parser.js
+++ b/test/parser.js
@@ -27,5 +27,10 @@ define([
 			parse(rule, '@xstyle end; test { property: value }');
 			assert.strictEqual(rule.rules, undefined);
 		},
+		'preserve escapes' : function () {
+			var rule = new Rule();
+			parse(rule, 'test { content: "\\e001" }');
+			assert.strictEqual(rule.rules.test.get('content')[0].value, '\\e001');
+		}
 	});
 });


### PR DESCRIPTION
This fixed a problem that I had were a rule like this:

``` css
.glyphicon-glass:before {
  content: "\e001";
}
```

was built into this:

``` css
.glyphicon-glass:before {content: "e001";}
```
