### PR TITLE
fixed use of getComputedStyle which can return null in firefox

### DIFF
--- a/css.js
+++ b/css.js
@@ -13,7 +13,7 @@ define(["require"], function(moduleRequire){
 		var docElement = document.documentElement;
 		var testDiv = docElement.insertBefore(document.createElement(tag), docElement.firstChild);
 		testDiv.id = id;
-		var styleValue = (testDiv.currentStyle || getComputedStyle(testDiv, null))[property];
+		var styleValue = (testDiv.currentStyle || getComputedStyle(testDiv, null) || {})[property];
 		docElement.removeChild(testDiv);
  		return styleValue;
  	} 


### PR DESCRIPTION
We have problems in firefox during load of iframes with style "display:none" cause getComputedStyle returns null for elemens in this iframe. Here is a fix to solve this problem.