### PR TITLE
Use fileUtils.compactPath instead of direct regex substitutions.

### DIFF
--- a/build.js
+++ b/build.js
@@ -49,12 +49,7 @@ if(typeof define == 'undefined'){
 		// must create our own path module for Rhino :/
 		pathModule = {
 			resolve: function(base, target){
-				target = (base.replace(/[^\/]+$/, '') + target);
-				var newTarget = target.replace(/\/[^\/]*\/\.\./g, '');
-				while(target !== (newTarget = target.replace(/\/[^\/]*\/\.\./g, ''))){
-					target = newTarget;
-				}
-				return target.replace(/\/\.\//g,'/');
+				return fileUtils.compactPath(base.replace(/[^\/]+$/, '') + target);
 			},
 			dirname: function(path){
 				return path.replace(/[\/\\][^\/\\]*$/, '');


### PR DESCRIPTION
This fixes pathModule.resolve's handling of /./../ and /../../ path
components similar to how commit e3c503cc fixes pathModule.join.