### PR TITLE
Check if cached CSS is {} before trying to inject it.

### DIFF
--- a/css.js
+++ b/css.js
@@ -36,9 +36,15 @@ define(["require"], function(moduleRequire){
 					var xCss =cachedCss.xCss;
 					cachedCss = cachedCss.cssText;
 				}
-				moduleRequire(['./core/load-css'],function(load){
-					checkForParser(load.insertCss(cachedCss));
-				});
+				// cachedCss might be {}, indicating this CSS was part of a built stylesheet. Assume the built
+				// stylesheet is already loaded, so no need to inject this CSS again.
+				if (typeof cachedCss == 'string') {
+					moduleRequire(['./core/load-css'],function(load){
+						checkForParser(load.insertCss(cachedCss));
+					});
+				} else {
+					checkForParser();
+				}
 				if(xCss){
 					//require([parsed], callback);
 				}


### PR DESCRIPTION
The build plugin interns ``xstyle/css!``-based dependencies as ``{}`` if the build layer has a target stylesheet. ``xstyle/css`` did not check for this and would blindly tried to inject the {} as the CSS, meaning we would get ``<style>[object Object]</style>`` added to the DOM.

This is a very tentative patch, because there are many ways of going about this. There seems to be a lot of overlap in how already-loaded CSS is detected: either via the ``cachedCss = {}`` mechanism, or by checking for a ``#<mid>-loaded CSS`` rule. If we go with the latter, then it seems like we should not intern the CSS into the layer JS file at all AND add the ``#<mid>-loaded`` markers for every CSS dependency (not just for the target stylesheet).