### PR TITLE
Ensure same order of stylesheets for built and non built environment

### DIFF
--- a/core/load-css.js
+++ b/core/load-css.js
@@ -16,7 +16,7 @@ define([], function(){
 			styleSheet = doc.createElement("style");
 			styleSheet.setAttribute("type", "text/css");
 			styleSheet.appendChild(doc.createTextNode(css));
-			head.insertBefore(styleSheet, head.firstChild);
+			head.appendChild(styleSheet);
 			return styleSheet;
 		}
 		else{


### PR DESCRIPTION
When using build/amd-css dojo build plugin, stylesheets are inserted as first children of head.
But in non build  environment they are appended as last children.
And if there are other style/link elements in head (static, not loaded by xstyle), they are in one case before xstyle elements, and in second one after them. And the order is significant when some rules have same 'strength'.

This commit changes the behavior, so also in build environment, stylesheets are appended as last children.