### PR TITLE
Empty css from require cached is wrongly processed 

### DIFF
--- a/css.js
+++ b/css.js
@@ -29,7 +29,7 @@ define(["require"], function(moduleRequire){
 				url = url.slice(0, -1);
 			}
 			var cachedCss = require.cache && require.cache['url:' + url];
-			if(cachedCss){
+			if(cachedCss != null){
 				// we have CSS cached inline in the build
 				if(cachedCss.xCss){
 					var parser = cachedCss.parser;


### PR DESCRIPTION
If css file is empty (or contains only comments), build/amd-css plugin will cause that it will appear as empty string in layer. And css.js will then wrongly consider it as not cached and will create link and load it.

(empty css are of course useless and should not be even referenced, but anyway this pull request will fix this wrong behavior)