### PR TITLE
URLs that contain only fragment will not be processed by build

### DIFF
--- a/build.js
+++ b/build.js
@@ -255,6 +255,9 @@ function processCss(cssText, basePath, cssPath, inlineAllResources){
 			if(url.match(/^data:/)){
 				return url;
 			}
+			if(/^#/.test(url)){ //do not replace urls which have only fragment (e.g. VML behavior property: "behavior: url(#default#VML);"")
+				return url;
+			}
 			if(inlineAllResources || /#inline$/.test(url)){
 				// we can inline the resource
 				suffix = url.match(/\.(\w+)(#|\?|$)/);


### PR DESCRIPTION
without this fix, build throws errors (`EISDIR: illegal operation on a directory, read`), e.g. for VML behaviour rules:  `behavior: url(#default#VML);`