### PR TITLE
whitespaces in selectors with '()' or '[]' are now preserved

### DIFF
--- a/core/parser.js
+++ b/core/parser.js
@@ -205,6 +205,10 @@ define('xstyle/core/parser', [], function(){
 								if(assignmentOperator == ':' && assignment){
 									first += assignment;
 								}
+								
+								if(first && whitespace){
+									first = whitespace + first;
+								}
 								selector = trim((selector + first).replace(/\s+/g, ' '));
 								// check to see if it is a correlator rule, from the build process
 								// add this new rule to the current parent rule


### PR DESCRIPTION
Fixes #61 

This change fixes our problems with missing whitespaces. But I didn't analyze the code in parser.js very deeply (and didn't run the intern tests) so maybe it's not the best place to fix.