### PR TITLE
Fix issue with whitespace being lost when a CSS rule contains a function-style pseudo class selector

### DIFF
--- a/core/parser.js
+++ b/core/parser.js
@@ -205,7 +205,7 @@ define('xstyle/core/parser', [], function(){
 								if(assignmentOperator == ':' && assignment){
 									first += assignment;
 								}
-								selector = trim((selector + first).replace(/\s+/g, ' '));
+								selector = trim((selector + (whitespace || '') + first).replace(/\s+/g, ' '));
 								// check to see if it is a correlator rule, from the build process
 								// add this new rule to the current parent rule
 								addInSequence(newTarget = target.newRule(selector));


### PR DESCRIPTION
This should fix issue #63.

When the parser was encountering something like `.st-grid:not(.fit-parent) .dgrid-header-row {`, it was dividing it into `.st-grid:not(.fit-parent)` and `.dgrid-header-row`.  It then stuck the two parts back together without the original whitespace that was in between thus changing the intent of the selector.